### PR TITLE
Time improvements

### DIFF
--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -3,6 +3,7 @@ module Pcloud
     class UnsuportedUpdateParams < StandardError; end
     class ManformedUpdateParams < StandardError; end
     class InvalidParameter < StandardError; end
+    class MissingParameter < StandardError; end
     class UploadFailed < StandardError; end
 
     include Parser
@@ -89,28 +90,24 @@ module Pcloud
       end
 
       def upload(params)
-        process_upload(
-          filename: params.fetch(:filename),
-          file: params.fetch(:file),
-          path: params[:path],
-          folder_id: params[:folder_id]
-        )
+        process_upload(params)
       end
 
       def upload!(params)
-        process_upload(
-          filename: params.fetch(:filename),
-          file: params.fetch(:file),
-          path: params[:path],
-          folder_id: params[:folder_id],
-          overwrite: true
-        )
+        process_upload(params.merge({ overwrite: true }))
       end
 
       private
 
       def process_upload(params)
-        raise InvalidParameter.new("The `file` parameter must be an instance of Ruby `File`") unless params.fetch(:file).is_a?(::File)
+        file = params.fetch(:file)
+        mtime = params[:modified_at]
+        ctime = params[:created_at]
+        raise InvalidParameter.new("The `file` parameter must be an instance of Ruby `File`") unless file.is_a?(::File)
+        raise InvalidParameter.new(":modified_at must be an instance of Ruby `Time`") if mtime && !mtime.is_a?(::Time)
+        raise InvalidParameter.new(":created_at must be an instance of Ruby `Time`") if ctime && !ctime.is_a?(::Time)
+        # Pcloud `ctime` param requires `mtime` to be present, but not the other way around
+        raise MissingParameter.new(":created_at parameter also requires :modified_at parameter to also be present") if ctime && !mtime
 
         # === pCloud API behavior notes: ===
         # 1. If neither `path` nor `folder_id` is provided, the file will be
@@ -124,7 +121,9 @@ module Pcloud
             path: params[:path],
             folderid: params[:folder_id],
             filename: params.fetch(:filename),
-            file: params.fetch(:file)
+            file: file,
+            mtime: mtime&.utc&.to_i, # must be in unix seconds
+            ctime: ctime&.utc&.to_i, # must be in unix seconds
           }.compact,
         )
         # This method on the pCloud API can accept multiple uploads at once.
@@ -133,6 +132,9 @@ module Pcloud
         uploaded_file = parse_many(response).first
         raise UploadFailed if uploaded_file.nil?
         return uploaded_file
+      rescue KeyError => e
+        missing_param = e.message.gsub("key not found: ", "")
+        raise MissingParameter.new("#{missing_param} is required")
       end
     end
   end

--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -88,29 +88,29 @@ module Pcloud
         parse_one(Client.execute("stat", query: { path: path }))
       end
 
-      def upload(filename:, file:, path: nil, folder_id: nil)
+      def upload(params)
         process_upload(
-          filename: filename,
-          file: file,
-          path: path,
-          folder_id: folder_id
+          filename: params.fetch(:filename),
+          file: params.fetch(:file),
+          path: params[:path],
+          folder_id: params[:folder_id]
         )
       end
 
-      def upload!(filename:, file:, path: nil, folder_id: nil)
+      def upload!(params)
         process_upload(
-          filename: filename,
-          file: file,
-          path: path,
-          folder_id: folder_id,
+          filename: params.fetch(:filename),
+          file: params.fetch(:file),
+          path: params[:path],
+          folder_id: params[:folder_id],
           overwrite: true
         )
       end
 
       private
 
-      def process_upload(filename:, file:, path: nil, folder_id: nil, overwrite: false)
-        raise InvalidParameter.new("The `file` parameter must be an instance of Ruby `File`") unless file.is_a?(::File)
+      def process_upload(params)
+        raise InvalidParameter.new("The `file` parameter must be an instance of Ruby `File`") unless params.fetch(:file).is_a?(::File)
 
         # === pCloud API behavior notes: ===
         # 1. If neither `path` nor `folder_id` is provided, the file will be
@@ -120,11 +120,11 @@ module Pcloud
         response = Client.execute(
           "uploadfile",
           body: {
-            renameifexists: overwrite ? 0 : 1,
-            path: path,
-            folderid: folder_id,
-            filename: filename,
-            file: file
+            renameifexists: params[:overwrite] ? 0 : 1,
+            path: params[:path],
+            folderid: params[:folder_id],
+            filename: params.fetch(:filename),
+            file: params.fetch(:file)
           }.compact,
         )
         # This method on the pCloud API can accept multiple uploads at once.

--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -4,7 +4,9 @@ module Pcloud
     class ManformedUpdateParams < StandardError; end
     class InvalidParameter < StandardError; end
     class UploadFailed < StandardError; end
+
     include Parser
+    include Pcloud::TimeHelper
 
     SUPPORTED_UPDATE_PARAMS = [:name, :parent_folder_id, :path].freeze
     FILE_CATAGORIES = {
@@ -28,8 +30,8 @@ module Pcloud
       @size = params.fetch(:size) # bytes
       @parent_folder_id = params.fetch(:parent_folder_id)
       @is_deleted = params.fetch(:is_deleted) || false
-      @created_at = params.fetch(:created_at)
-      @modified_at = params.fetch(:modified_at)
+      @created_at = time_from(params.fetch(:created_at))
+      @modified_at = time_from(params.fetch(:modified_at))
     end
 
     def update(params)
@@ -73,7 +75,7 @@ module Pcloud
     private
 
     def is_invalid_path_param?(path_param)
-      # Path params have to start and end with `/``
+      # Path params have to start and end with `/`
       [path_param[0], path_param[-1]] != ["/", "/"]
     end
 

--- a/lib/pcloud/folder.rb
+++ b/lib/pcloud/folder.rb
@@ -3,7 +3,9 @@ module Pcloud
     class UnsuportedUpdateParams < StandardError; end
     class ManformedUpdateParams < StandardError; end
     class InvalidCreateParams < StandardError; end
+
     include Parser
+    include Pcloud::TimeHelper
 
     SUPPORTED_UPDATE_PARAMS = [:name, :parent_folder_id, :path].freeze
 
@@ -23,8 +25,8 @@ module Pcloud
       # have any contents set yet.
       @contents_are_confirmed = @contents && @contents.size > 0
       @is_deleted = params.fetch(:is_deleted) || false
-      @created_at = params.fetch(:created_at)
-      @modified_at = params.fetch(:modified_at)
+      @created_at = time_from(params.fetch(:created_at))
+      @modified_at = time_from(params.fetch(:modified_at))
     end
 
     def update(params)
@@ -72,7 +74,7 @@ module Pcloud
     private
 
     def is_invalid_path_param?(path_param)
-      # Path params have to start and end with `/``
+      # Path params have to start and end with `/`
       [path_param[0], path_param[-1]] != ["/", "/"]
     end
 

--- a/lib/pcloud/time_helper.rb
+++ b/lib/pcloud/time_helper.rb
@@ -1,0 +1,26 @@
+module Pcloud
+  module TimeHelper
+    class UnrecognizedTimeFormat < StandardError; end
+
+    TIMEZONE = TZInfo::Timezone.get(ENV.fetch("TZ", "UTC")).freeze
+
+    protected
+
+    def time_from(time)
+      time_object =
+        if time.is_a?(String)
+          Time.parse(time)
+        elsif time.is_a?(Integer)
+          return Time.at(time) if time.digits.size < 13
+          milliseconds = time.to_s[-3..-1].to_i
+          seconds = time.to_s[0..-4].to_i
+          Time.at(seconds, milliseconds, :millisecond)
+        elsif time.is_a?(Time)
+          time
+        else
+          raise Pcloud::TimeHelper::UnrecognizedTimeFormat.new(time.inspect)
+        end
+      TIMEZONE.to_local(time_object)
+    end
+  end
+end

--- a/lib/pcloud_api.rb
+++ b/lib/pcloud_api.rb
@@ -1,7 +1,9 @@
 require "httparty"
+require "tzinfo"
 require "json"
 
 require "pcloud/version"
+require "pcloud/time_helper"
 require "pcloud/file/parser"
 require "pcloud/file"
 require "pcloud/folder/parser"

--- a/pcloud_api.gemspec
+++ b/pcloud_api.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.13"
 
   spec.add_dependency "httparty", "~> 0.16"
+  spec.add_dependency "tzinfo"
 end

--- a/spec/pcloud/time_helper_spec.rb
+++ b/spec/pcloud/time_helper_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Pcloud::TimeHelper do
+  class TestClass
+    include Pcloud::TimeHelper
+  end
+
+  let(:subject) { TestClass.new }
+  let(:time) { Time.now }
+
+  describe "#from_time" do
+    it "returns a time object" do
+      expect(subject.send(:time_from, time)).to be_a(Time)
+    end
+
+    it "parses a time object" do
+      expect(subject.send(:time_from, time)).to eq(time.utc.floor(6))
+    end
+
+    it "parses a string timestamp" do
+      expect(subject.send(:time_from, time.to_s)).to eq(time.utc.floor(0))
+    end
+
+    it "parses an integer timestamp in seconds" do
+      expect(subject.send(:time_from, time.to_i)).to eq(time.utc.floor(0))
+    end
+
+    it "parses an integer timestamp in milliseconds" do
+      expect(
+        subject.send(:time_from, (time.to_f * 1000).to_i)
+      ).to eq(time.utc.floor(3))
+    end
+
+    it "respects the TZ environment varaible" do
+      allow(ENV).to receive(:[]).with("TZ").and_return("America/Los_Angeles")
+      expected_local_timezone_time = TZInfo::Timezone
+        .get("America/Los_Angeles")
+        .to_local(time)
+        .floor(6) # includes milliseconds
+      expect(subject.send(:time_from, time)).to eq(expected_local_timezone_time)
+    end
+
+    it "raises on unrecognized time format" do
+      expect {
+        subject.send(:time_from, Array(time.to_s))
+      }.to raise_error(Pcloud::TimeHelper::UnrecognizedTimeFormat, "[\"#{time.to_s}\"]")
+    end
+  end
+end


### PR DESCRIPTION
### Description:
- Allow user to specify `mtime` and `ctime` properties on file upload *(pCloud requires these be passed in Unix time seconds, and that ctime always be paired with mtime but not necissarily the other way around.)*
- Return `created_at` and `modified_at` as Ruby time objects instead of strings
	- Respect server time zone + read the same `TZ` env var that Heroku uses

### Testing:
Test suite updated