### PR TITLE
Add exists? and additional cleanup

### DIFF
--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -90,11 +90,17 @@ module Pcloud
       end
 
       def find(id)
-        parse_one(Client.execute("stat", query: { fileid: id }))
+        find_by(id: id)
       end
 
-      def find_by(path:)
-        parse_one(Client.execute("stat", query: { path: path }))
+      def find_by(params)
+        raise MissingParameter.new(":path or :id is required") unless params[:path] || params[:id]
+        parse_one(
+          Client.execute(
+            "stat",
+            query: { path: params[:path], fileid: params[:id] }.compact
+          )
+        )
       end
 
       def upload(params)
@@ -115,7 +121,7 @@ module Pcloud
         raise InvalidParameter.new(":modified_at must be an instance of Ruby `Time`") if mtime && !mtime.is_a?(::Time)
         raise InvalidParameter.new(":created_at must be an instance of Ruby `Time`") if ctime && !ctime.is_a?(::Time)
         # Pcloud `ctime` param requires `mtime` to be present, but not the other way around
-        raise MissingParameter.new(":created_at parameter also requires :modified_at parameter to also be present") if ctime && !mtime
+        raise MissingParameter.new(":created_at requires :modified_at to also be present") if ctime && !mtime
 
         # === pCloud API behavior notes: ===
         # 1. If neither `path` nor `folder_id` is provided, the file will be

--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -90,7 +90,7 @@ module Pcloud
       end
 
       def find(id)
-        find_by(id: id)
+        parse_one(Client.execute("stat", query: { fileid: id }))
       end
 
       def find_by(params)

--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -81,6 +81,14 @@ module Pcloud
     end
 
     class << self
+      def exists?(id)
+        find(id)
+        true
+      rescue Pcloud::Client::ErrorResponse => e
+        return false if e.message == "File not found."
+        raise e
+      end
+
       def find(id)
         parse_one(Client.execute("stat", query: { fileid: id }))
       end

--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -1,8 +1,8 @@
 module Pcloud
   class File
-    class UnsuportedUpdateParams < StandardError; end
     class ManformedUpdateParams < StandardError; end
     class InvalidParameter < StandardError; end
+    class InvalidParameters < StandardError; end
     class MissingParameter < StandardError; end
     class UploadFailed < StandardError; end
 
@@ -37,10 +37,10 @@ module Pcloud
 
     def update(params)
       unless (params.keys - SUPPORTED_UPDATE_PARAMS).empty?
-        raise UnsuportedUpdateParams.new("Must be one of #{SUPPORTED_UPDATE_PARAMS}")
+        raise InvalidParameters.new("Must be one of #{SUPPORTED_UPDATE_PARAMS}")
       end
       if params[:path] && is_invalid_path_param?(params[:path])
-        raise ManformedUpdateParams.new("`path` param must start and end with `/`")
+        raise ManformedUpdateParams.new(":path param must start and end with `/`")
       end
       query = {
         fileid: id,
@@ -95,6 +95,7 @@ module Pcloud
 
       def find_by(params)
         raise MissingParameter.new(":path or :id is required") unless params[:path] || params[:id]
+        raise InvalidParameters.new(":id takes precedent over :path, please only use one or the other") if params[:path] && params[:id]
         parse_one(
           Client.execute(
             "stat",

--- a/lib/pcloud/folder.rb
+++ b/lib/pcloud/folder.rb
@@ -99,7 +99,7 @@ module Pcloud
       end
 
       def find(id)
-        find_by(id: id)
+        parse_one(Client.execute("listfolder", query: { folderid: id }))
       end
 
       def find_by(params)

--- a/lib/pcloud/folder.rb
+++ b/lib/pcloud/folder.rb
@@ -3,6 +3,7 @@ module Pcloud
     class UnsuportedUpdateParams < StandardError; end
     class ManformedUpdateParams < StandardError; end
     class InvalidCreateParams < StandardError; end
+    class MissingParameter < StandardError; end
 
     include Parser
     include Pcloud::TimeHelper
@@ -98,11 +99,17 @@ module Pcloud
       end
 
       def find(id)
-        parse_one(Client.execute("listfolder", query: { folderid: id }))
+        find_by(id: id)
       end
 
-      def find_by(path:)
-        parse_one(Client.execute("listfolder", query: { path: path }))
+      def find_by(params)
+        raise MissingParameter.new(":path or :id is required") unless params[:path] || params[:id]
+        parse_one(
+          Client.execute(
+            "listfolder",
+            query: { path: params[:path], folderid: params[:id] }.compact
+          )
+        )
       end
     end
   end

--- a/lib/pcloud/folder.rb
+++ b/lib/pcloud/folder.rb
@@ -89,6 +89,14 @@ module Pcloud
         end
       end
 
+      def exists?(id)
+        find(id)
+        true
+      rescue Pcloud::Client::ErrorResponse => e
+        return false if e.message == "Directory does not exist."
+        raise e
+      end
+
       def find(id)
         parse_one(Client.execute("listfolder", query: { folderid: id }))
       end

--- a/spec/pcloud/file_spec.rb
+++ b/spec/pcloud/file_spec.rb
@@ -165,11 +165,11 @@ RSpec.describe Pcloud::File do
     end
 
     context "with unsupported update params" do
-      it "raises UnsuportedUpdateParams and does not make a web request" do
+      it "raises InvalidParameters and does not make a web request" do
         expect(Pcloud::Client).to receive(:execute).never
         expect {
           cat_photo.update(coolness_points: 1000000000)
-        }.to raise_error(Pcloud::File::UnsuportedUpdateParams, "Must be one of [:name, :parent_folder_id, :path]")
+        }.to raise_error(Pcloud::File::InvalidParameters, "Must be one of [:name, :parent_folder_id, :path]")
       end
     end
 
@@ -177,7 +177,7 @@ RSpec.describe Pcloud::File do
       it "raises ManformedUpdateParams and does not make a web request" do
         expect {
           cat_photo.update(path: "/images")
-        }.to raise_error(Pcloud::File::ManformedUpdateParams, "`path` param must start and end with `/`")
+        }.to raise_error(Pcloud::File::ManformedUpdateParams, ":path param must start and end with `/`")
       end
     end
   end
@@ -403,10 +403,19 @@ RSpec.describe Pcloud::File do
       expect(response.name).to eq(cat_photo.name)
     end
 
-    it "raises MissingParameter with invalid parameters" do
+    it "raises MissingParameter with missing parameters" do
       expect {
         Pcloud::File.find_by(feeling: "happy")
       }.to raise_error(Pcloud::File::MissingParameter, ":path or :id is required")
+    end
+
+    it "raises InvalidParameters with invalid parameters" do
+      expect {
+        Pcloud::File.find_by(path: "/cats.jpg", id: 100100)
+      }.to raise_error(
+        Pcloud::File::InvalidParameters,
+        ":id takes precedent over :path, please only use one or the other"
+      )
     end
   end
 

--- a/spec/pcloud/file_spec.rb
+++ b/spec/pcloud/file_spec.rb
@@ -295,6 +295,37 @@ RSpec.describe Pcloud::File do
     end
   end
 
+  describe ".exists?" do
+    it "calls .find" do
+      expect(Pcloud::File).to receive(:find).with(1)
+      Pcloud::File.exists?(1)
+    end
+
+    it "returns false when no file is found" do
+      allow(Pcloud::File)
+        .to receive(:find)
+        .with(1)
+        .and_raise(Pcloud::Client::ErrorResponse.new("File not found."))
+      expect(Pcloud::File.exists?(1)).to eq(false)
+    end
+
+    it "returns true when a file is found" do
+      allow(Pcloud::File).to receive(:find).and_return(cat_photo)
+      expect(Pcloud::File.exists?(1)).to eq(true)
+    end
+
+    it "re-raises unexpected errors" do
+      expected_error = Pcloud::Client::ErrorResponse.new("File is too funny.")
+      allow(Pcloud::File)
+        .to receive(:find)
+        .with(1)
+        .and_raise(expected_error)
+      expect {
+        Pcloud::File.exists?(1)
+      }.to raise_error(expected_error)
+    end
+  end
+
   describe ".find" do
     let(:stat_response) do
       {

--- a/spec/pcloud/file_spec.rb
+++ b/spec/pcloud/file_spec.rb
@@ -402,6 +402,12 @@ RSpec.describe Pcloud::File do
       expect(response.id).to eq(cat_photo.id)
       expect(response.name).to eq(cat_photo.name)
     end
+
+    it "raises MissingParameter with invalid parameters" do
+      expect {
+        Pcloud::File.find_by(feeling: "happy")
+      }.to raise_error(Pcloud::File::MissingParameter, ":path or :id is required")
+    end
   end
 
   describe ".upload" do
@@ -517,7 +523,7 @@ RSpec.describe Pcloud::File do
             )
           }.to raise_error(
             Pcloud::File::MissingParameter,
-            ":created_at parameter also requires :modified_at parameter to also be present"
+            ":created_at requires :modified_at to also be present"
           )
         end
 

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -446,7 +446,38 @@ RSpec.describe Pcloud::Folder do
     end
   end
 
-  describe "#find" do
+  describe ".exists?" do
+    it "calls .find" do
+      expect(Pcloud::Folder).to receive(:find).with(1)
+      Pcloud::Folder.exists?(1)
+    end
+
+    it "returns false when no folder is found" do
+      allow(Pcloud::Folder)
+        .to receive(:find)
+        .with(1)
+        .and_raise(Pcloud::Client::ErrorResponse.new("Directory does not exist."))
+      expect(Pcloud::Folder.exists?(1)).to eq(false)
+    end
+
+    it "returns true when a folder is found" do
+      allow(Pcloud::Folder).to receive(:find).and_return(jacks_folder)
+      expect(Pcloud::Folder.exists?(1)).to eq(true)
+    end
+
+    it "re-raises unexpected errors" do
+      expected_error = Pcloud::Client::ErrorResponse.new("Folder contents are too funny.")
+      allow(Pcloud::Folder)
+        .to receive(:find)
+        .with(1)
+        .and_raise(expected_error)
+      expect {
+        Pcloud::Folder.exists?(1)
+      }.to raise_error(expected_error)
+    end
+  end
+
+  describe ".find" do
     let(:find_response) do
       {
         "metadata" => {
@@ -510,7 +541,7 @@ RSpec.describe Pcloud::Folder do
     end
   end
 
-  describe "#find_by" do
+  describe ".find_by" do
     let(:find_by_response) do
       {
         "metadata" => {

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Pcloud::Folder do
       it "raises ManformedUpdateParams and does not make a web request" do
         expect {
           jacks_folder.update(path: "/jack_images")
-        }.to raise_error(Pcloud::Folder::ManformedUpdateParams, "`path` param must start and end with `/`")
+        }.to raise_error(Pcloud::Folder::ManformedUpdateParams, ":path param must start and end with `/`")
       end
     end
   end

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -439,8 +439,8 @@ RSpec.describe Pcloud::Folder do
         expect {
           Pcloud::Folder.first_or_create(name: "jacks_folder")
         }.to raise_error(
-          Pcloud::Folder::InvalidCreateParams,
-          "first_or_create must be called with either `path` or both `parent_folder_id` and `name` params"
+          Pcloud::Folder::InvalidParameters,
+          "either :path or a combination of :parent_folder_id and :name params are required"
         )
       end
     end
@@ -604,10 +604,19 @@ RSpec.describe Pcloud::Folder do
       expect(contents.last).to be_a(Pcloud::Folder)
     end
 
-    it "raises MissingParameter with invalid parameters" do
+    it "raises MissingParameter with missing parameters" do
       expect {
         Pcloud::Folder.find_by(feeling: "happy")
       }.to raise_error(Pcloud::Folder::MissingParameter, ":path or :id is required")
+    end
+
+    it "raises InvalidParameters with invalid parameters" do
+      expect {
+        Pcloud::Folder.find_by(path: "/jacks_folder", id: 9000)
+      }.to raise_error(
+        Pcloud::Folder::InvalidParameters,
+        ":id takes precedent over :path, please only use one or the other"
+      )
     end
   end
 end

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -603,5 +603,11 @@ RSpec.describe Pcloud::Folder do
       expect(contents.first).to be_a(Pcloud::File)
       expect(contents.last).to be_a(Pcloud::Folder)
     end
+
+    it "raises MissingParameter with invalid parameters" do
+      expect {
+        Pcloud::Folder.find_by(feeling: "happy")
+      }.to raise_error(Pcloud::Folder::MissingParameter, ":path or :id is required")
+    end
   end
 end


### PR DESCRIPTION
### Description:
This PR adds the `.exists?` method to both `Pcloud::File` and `Pcloud::Folder` objects. In addition, I've included some cleanup to error messages and additional support in the `.find_by` method for either `:id` or `:path`. Unfortunately, pCloud treats these parameters with a precedence, so I've added an error message to warn users trying to call the method with both params at once.

### Testing:
Test suite updated