### PR TITLE
More flexible paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3 2021-12-14
+
+**Changes**
+  1. `Pcloud::File`'s `upload` method no longer requires a `:filename` param, since pCloud just reads it off of the file object and ignores the param anyway
+  2. Both `Pcloud::File` and `Pcloud::Folder`'s `update` and `update!` methods now allow either partial paths _(starting and ending with slashes)_ or full paths. This is a little more dangerous if you specify a full path and you meant partial, but it's a reasonable use case to support.
+
 ## 0.2.2 2021-10-09
 
 **Changes**

--- a/README.md
+++ b/README.md
@@ -52,37 +52,44 @@ There are two main objects represented in the library, `Pcloud::File` and `Pclou
 
 The `Pcloud::File` API includes:
 ```ruby
-# Find files by file id or path:
+# Find files by file :id or :path:
 Pcloud::File.find(1)
 Pcloud::File.find_by(path: "/images/jack_the_cat.jpg")
-# NOTE: find_by can also be used with :id, though this will take precedence
+# NOTE: `find_by` can also be used with :id, though this will take precedence
 # over :path so just pick one or the other
 
-# Check if a file exists by id
+# Check if a file exists by :id
 Pcloud::File.exists?(1)
 
 # Upload a new file, rename if one already exists with this name:
 Pcloud::File.upload(
-  folder_id: 1,
-  filename: "jack_goes_swimming.mp4",
+  path: "/Jack",
   file: File.open("/Users/joshua/Downloads/jack_goes_swimming.mp4")
 )
-# NOTE: the upload method will allow you to specify the :path or the :folder_id
-# or you can choose to pass neither paramenter and your files will be placed
-# in your root pCloud directory.
 
-# Upload a file, force overwrite of existing file:
+# Upload a file, force overwrite if a file already exists with this name:
 Pcloud::File.upload!(
-  folder_id: 1,
-  filename: "jack_goes_swimming.mp4",
+  path: "/Jack",
   file: File.open("/Users/joshua/Downloads/jack_goes_swimming.mp4")
 )
+
+# NOTE:
+# The `upload` and `upload!` methods will allow you to specify either the :path
+# or the :folder_id of the target parent directory, or you can choose to pass
+# neither paramenter and your files will be placed in your root pCloud
+# directory by default.
 
 # Rename a file:
 jack_goes_swimming.update(name: "That's one wet cat.mp4")
 
-# Move a file by updating the parent_folder_id or path:
+# Move a file by updating the :parent_folder_id:
 jack_goes_swimming.update(parent_folder_id: 9000)
+
+# Move a file by specifying the parent folder part of the path:
+jack_goes_swimming.update(path: "/photos/") # NOTE: needs to start and end with slashes
+
+# Move a file by specifying the entire new file path:
+jack_goes_swimming.update(path: "/photos/jack_goes_swimming.mp4")
 
 # Delete a file:
 jack_goes_swimming.delete
@@ -96,26 +103,36 @@ jack_goes_swimming.parent_folder
 
 The `Pcloud::Folder` API is very similar:
 ```ruby
-# Find folders by folder id or path:
+# Find folders by folder :id or :path:
 Pcloud::Folder.find(1)
 Pcloud::Folder.find_by(path: "/images")
-# NOTE: find_by can also be used with :id, though this will take precedence
+# NOTE: `find_by` can also be used with :id, though this will take precedence
 # over :path so just pick one or the other
 
 # Check if a folder exists by id
 Pcloud::Folder.exists?(1)
 
-# Create a new folder by parent_folder_id and name:
+# Create a new folder by :parent_folder_id and :name:
 Pcloud::Folder.first_or_create(parent_folder_id: 9000, name: "jack")
 
-# Create a new folder by path:
+# Create a new folder by :path (parent directory must already exist):
 Pcloud::Folder.first_or_create(path: "/images/jack")
 
 # Rename a folder:
 jack_images.update(name: "Jack's Photo Library")
 
-# Move a folder by updating the parent_folder_id or path:
+# Move a folder by updating the :parent_folder_id:
 jack_images.update(parent_folder_id: 9000)
+
+# Move a folder by specifying the parent folder part of the path:
+jack_images.update(path: "/photos/")
+# NOTES:
+# - Partial paths must start and end with slashes
+# - All refrenced parent directories in the path must already exist
+
+# Move a folder by specifying the entire new file path:
+jack_images.update(path: "/photos/images/jack")
+# NOTE: All refrenced parent directories in the path must already exist
 
 # Delete an empty folder:
 jack_images.delete

--- a/lib/pcloud/file.rb
+++ b/lib/pcloud/file.rb
@@ -39,8 +39,8 @@ module Pcloud
       unless (params.keys - SUPPORTED_UPDATE_PARAMS).empty?
         raise InvalidParameters.new("Must be one of #{SUPPORTED_UPDATE_PARAMS}")
       end
-      if params[:path] && is_invalid_path_update_param?(params[:path])
-        raise InvalidParameter.new(":path param must start and end with `/`")
+      if params[:path] && params[:path][0] != "/"
+        raise InvalidParameter.new(":path param must start with `/`")
       end
       query = {
         fileid: id,
@@ -71,13 +71,6 @@ module Pcloud
       # a download URL from pcloud, while maintaining consistency if the file
       # name changes later.
       "#{@download_url}/#{URI.encode_www_form_component(name)}"
-    end
-
-    private
-
-    def is_invalid_path_update_param?(path_param)
-      # Path params have to start and end with `/` when used with .update
-      [path_param[0], path_param[-1]] != ["/", "/"]
     end
 
     class << self
@@ -127,7 +120,7 @@ module Pcloud
             renameifexists: params[:overwrite] ? 0 : 1,
             path: params[:path],
             folderid: params[:folder_id],
-            filename: params.fetch(:filename),
+            filename: params[:filename],
             file: file,
           }.compact,
         )

--- a/lib/pcloud/folder.rb
+++ b/lib/pcloud/folder.rb
@@ -34,8 +34,8 @@ module Pcloud
       unless (params.keys - SUPPORTED_UPDATE_PARAMS).empty?
         raise InvalidParameters.new("Must be one of #{SUPPORTED_UPDATE_PARAMS}")
       end
-      if params[:path] && is_invalid_path_param?(params[:path])
-        raise InvalidParameter.new(":path parameter must start and end with `/`")
+      if params[:path] && params[:path][0] != "/"
+        raise InvalidParameter.new(":path parameter must start with `/`")
       end
       query = {
         folderid: id,
@@ -70,13 +70,6 @@ module Pcloud
       @contents = Folder.find(id).contents
       @contents_are_confirmed = true
       @contents
-    end
-
-    private
-
-    def is_invalid_path_param?(path_param)
-      # Path params have to start and end with `/`
-      [path_param[0], path_param[-1]] != ["/", "/"]
     end
 
     class << self

--- a/lib/pcloud/version.rb
+++ b/lib/pcloud/version.rb
@@ -1,3 +1,3 @@
 module Pcloud
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/pcloud/file_spec.rb
+++ b/spec/pcloud/file_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe Pcloud::File do
       it "raises InvalidParameter and does not make a web request" do
         expect(Pcloud::Client).to receive(:execute).never
         expect {
-          cat_photo.update(path: "/images")
-        }.to raise_error(Pcloud::File::InvalidParameter, ":path param must start and end with `/`")
+          cat_photo.update(path: "images")
+        }.to raise_error(Pcloud::File::InvalidParameter, ":path param must start with `/`")
       end
     end
   end
@@ -457,12 +457,6 @@ RSpec.describe Pcloud::File do
 
     context "with a valid file object" do
       let(:sleepy_cat_image_file) { File.open("spec/fixtures/sleepy_cat.jpg") }
-
-      it "requires a filename param" do
-        expect {
-          Pcloud::File.upload(file: sleepy_cat_image_file)
-        }.to raise_error(Pcloud::File::MissingParameter, ":filename is required")
-      end
 
       it "makes an uploadfile request" do
         expect(Pcloud::Client)

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -229,8 +229,8 @@ RSpec.describe Pcloud::Folder do
       it "raises InvalidParameter and does not make a web request" do
         expect(Pcloud::Client).to receive(:execute).never
         expect {
-          jacks_folder.update(path: "/jack_images")
-        }.to raise_error(Pcloud::Folder::InvalidParameter, ":path parameter must start and end with `/`")
+          jacks_folder.update(path: "jack_images")
+        }.to raise_error(Pcloud::Folder::InvalidParameter, ":path parameter must start with `/`")
       end
     end
   end


### PR DESCRIPTION
This PR adds some additional README clarifications as well as two improvements to the gem's interface:
1. `Pcloud::File`'s `upload` method no longer requires a `:filename` param, since pCloud just reads it off of the file object and ignores the param anyway
2. Both `Pcloud::File` and `Pcloud::Folder`'s `update` and `update!` methods now allow either partial paths _(starting and ending with slashes)_ or full paths. NOTE: This behavior was previously prevented because it makes it possible possible to get yourself into a mess if you specify a full path and you meant a partial path, but it's a reasonable use case to support. Sharp knives and all that.