### PR TITLE
Add  `recursive` option to folder finding

### DIFF
--- a/lib/pcloud/folder.rb
+++ b/lib/pcloud/folder.rb
@@ -8,7 +8,7 @@ module Pcloud
     include Pcloud::TimeHelper
 
     SUPPORTED_UPDATE_PARAMS = [:name, :parent_folder_id, :path].freeze
-    SUPPORTED_FIND_BY_PARAMS = [:id, :path].freeze
+    SUPPORTED_FIND_BY_PARAMS = [:id, :path, :recursive].freeze
 
     attr_reader :id, :path, :name, :parent_folder_id, :is_deleted, :created_at,
                 :modified_at
@@ -91,8 +91,8 @@ module Pcloud
         raise e
       end
 
-      def find(id)
-        parse_one(Client.execute("listfolder", query: { folderid: id }))
+      def find(id, opts={})
+        parse_one(Client.execute("listfolder", query: { folderid: id, recursive: opts[:recursive] == true }))
       end
 
       def find_by(params)
@@ -100,7 +100,7 @@ module Pcloud
           raise InvalidParameters.new("Must be one of #{SUPPORTED_FIND_BY_PARAMS}")
         end
         raise InvalidParameters.new(":id takes precedent over :path, please only use one or the other") if params[:path] && params[:id]
-        query = { path: params[:path], folderid: params[:id] }.compact
+        query = { path: params[:path], folderid: params[:id], recursive: params[:recursive] == true }.compact
         parse_one(Client.execute("listfolder", query: query))
       end
     end

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -523,9 +523,19 @@ RSpec.describe Pcloud::Folder do
         .to receive(:execute)
         .with(
           "listfolder",
-          query: { folderid: 9000 }
+          query: { folderid: 9000, recursive: false }
         )
       Pcloud::Folder.find(9000)
+    end
+
+    it "makes a recursive listfolder request when option is passed" do
+      expect(Pcloud::Client)
+        .to receive(:execute)
+        .with(
+          "listfolder",
+          query: { folderid: 9000, recursive: true }
+        )
+      Pcloud::Folder.find(9000, recursive: true)
     end
 
     it "returns a Pcloud::Folder" do
@@ -582,14 +592,34 @@ RSpec.describe Pcloud::Folder do
       allow(Pcloud::Client).to receive(:execute).and_return(find_by_response)
     end
 
-    it "makes a listfolder request" do
+    it "makes a listfolder request by path" do
       expect(Pcloud::Client)
         .to receive(:execute)
         .with(
           "listfolder",
-          query: { path: "/jacks_folder" }
+          query: { path: "/jacks_folder", recursive: false }
         )
       Pcloud::Folder.find_by(path: "/jacks_folder")
+    end
+
+    it "makes a listfolder request by id" do
+      expect(Pcloud::Client)
+        .to receive(:execute)
+        .with(
+          "listfolder",
+          query: { folderid: 9000, recursive: false }
+        )
+      Pcloud::Folder.find_by(id: 9000)
+    end
+
+    it "makes a recursive listfolder request when option is passed" do
+      expect(Pcloud::Client)
+        .to receive(:execute)
+        .with(
+          "listfolder",
+          query: { path: "/jacks_folder", recursive: true }
+        )
+      Pcloud::Folder.find_by(path: "/jacks_folder", recursive: true)
     end
 
     it "returns a Pcloud::Folder" do
@@ -610,7 +640,7 @@ RSpec.describe Pcloud::Folder do
         expect(Pcloud::Client).to receive(:execute).never
         expect {
           Pcloud::Folder.find_by(feeling: "happy")
-        }.to raise_error(Pcloud::Folder::InvalidParameters, "Must be one of [:id, :path]")
+        }.to raise_error(Pcloud::Folder::InvalidParameters, "Must be one of [:id, :path, :recursive]")
       end
     end
 


### PR DESCRIPTION
### Description:

Resolves https://github.com/jhunschejones/pcloud_api/issues/11 by adding support for an optional `recursive` argument to folder finding methods. When this option is passed the pCloud API returns the folder with all its contents recursively. NOTE: this can result in a much longer web request, but may be worth the tradeoff in some use cases.

**Reference docs:** https://docs.pcloud.com/methods/folder/listfolder.html