### PR TITLE
Allow client timeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Gem Version](https://badge.fury.io/rb/pcloud_api.svg)](https://badge.fury.io/rb/pcloud_api)
 [![Gem Downloads](https://badgen.net/rubygems/dt/pcloud_api)](https://rubygems.org/gems/pcloud_api)
 
-The `pcloud_api` gem provides an intuitive Ruby interface for interacting with the [pCloud API](https://docs.pcloud.com/) using OAuth2. This gem does not attempt to replicate the entire functionality of the pCloud API but rather to provide quick and easy access for its most basic and common functionality. If you are looking for a lower-level pCloud API wrapper, [`pcloud`](https://github.com/7urkm3n/pcloud) might be a better fit for you.
+The `pcloud_api` gem provides an intuitive Ruby interface for interacting with the [pCloud API](https://docs.pcloud.com/) using OAuth2. This gem does not attempt to replicate the entire functionality of the pCloud API but rather to provide quick and easy access for its most important functionality. If you are looking for a lower-level pCloud API wrapper, [`pcloud`](https://github.com/7urkm3n/pcloud) might be a better fit for you.
 
 ## Installation
 
@@ -41,6 +41,7 @@ The `Pcloud::Client` can be configured by directly calling the `Pcloud::Client.c
 Pcloud::Client.configure(
   access_token: "your-pcloud-app-access-token",
   data_region: "EU"
+  timeout_seconds: 8 # optional integer, defaults to 8 seconds if not specified
 )
 ```
 
@@ -106,7 +107,7 @@ The `Pcloud::Folder` API is very similar:
 # Find folders by folder :id or :path:
 Pcloud::Folder.find(1)
 Pcloud::Folder.find_by(path: "/images")
-# NOTES: 
+# NOTES:
 # - `find_by` can also be used with :id, though this will take precedence over :path so pick only one or the other
 # - When using :path the folder object will have a `path` value, when finding by :id, `path` will be `nil`
 

--- a/lib/pcloud/client.rb
+++ b/lib/pcloud/client.rb
@@ -9,20 +9,21 @@ module Pcloud
     ].freeze
     US_API_BASE = "api.pcloud.com".freeze
     EU_API_BASE = "eapi.pcloud.com".freeze
-    TIMEOUT_SECONDS = ENV.fetch("PCLOUD_API_TIMEOUT_SECONDS", "8").to_i.freeze
+    DEFAULT_TIMEOUT_SECONDS = 8.freeze
 
     class << self
-      def configure(access_token: nil, data_region: nil)
+      def configure(access_token: nil, data_region: nil, timeout_seconds: nil)
         @@access_token = access_token
         @@data_region = data_region
+        @@timeout_seconds = timeout_seconds.nil? ? nil : timeout_seconds.to_i
         true # Don't accidentally return any secrets from the configure method
       end
 
       def execute(method, query: {}, body: {})
         verb = ["uploadfile"].include?(method) ? :post : :get
         options = {
-          headers: { "Authorization" => "Bearer #{access_token}" },
-          timeout: TIMEOUT_SECONDS # this sets both the open and read timeouts to the same value
+          headers: { "Authorization" => "Bearer #{access_token_from_config_or_env}" },
+          timeout: timeout_seconds_from_config_or_env # this sets both the open and read timeouts to the same value
         }
         options[:query] = query unless query.empty?
         options[:body] = body unless body.empty?
@@ -34,17 +35,23 @@ module Pcloud
 
       private
 
-      def data_region
+      def data_region_from_config_or_env
         @@data_region ||= ENV["PCLOUD_API_DATA_REGION"]
         return @@data_region if VALID_DATA_REGIONS.include?(@@data_region)
         raise ConfigurationError.new("Missing pCloud data region") if @@data_region.nil?
         raise ConfigurationError.new("Invalid pCloud data region, must be one of #{VALID_DATA_REGIONS}")
       end
 
-      def access_token
+      def access_token_from_config_or_env
         @@access_token ||= ENV["PCLOUD_API_ACCESS_TOKEN"]
         return @@access_token unless @@access_token.nil?
         raise ConfigurationError.new("Missing pCloud API access token")
+      end
+
+      def timeout_seconds_from_config_or_env
+        @@timeout_seconds ||= ENV.fetch("PCLOUD_API_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS).to_i
+        return @@timeout_seconds unless @@timeout_seconds.zero?
+        raise ConfigurationError.new("Invalid pCloud API timeout seconds: cannot be set to 0")
       end
 
       # You can manually hit "https://<default_server_for_your_region>/getapiserver"
@@ -53,7 +60,7 @@ module Pcloud
       def closest_server
         @@closest_server ||= begin
           return ENV["PCLOUD_API_BASE_URI"] if ENV["PCLOUD_API_BASE_URI"]
-          case data_region
+          case data_region_from_config_or_env
           when US_DATA_REGION
             US_API_BASE
           when EU_DATA_REGION


### PR DESCRIPTION
### Description:

This change exposes the pCloud API timeout seconds configuration as a client configuration argument. Previously this was setting was only configurable via the `PCLOUD_API_TIMEOUT_SECONDS` environment variable. After this change, both the config setting or the environment variable will work, with preference given to the setting provided on the client.

BONUS:
I've also renamed some private methods on the client to make the code a little easier to differentiate what is a variable and what is a method 😅  