### PR TITLE
🐛  Fix recursive folder parsing and prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.2.3 2021-12-14
+## 0.2.5 2023-05-05
+
+**Bugfix**
+  1. When passing the optipnal `recursive: true` on `Pcloud::Folder#find` or `Pcloud::Folder#find_by` methods to load all the folders contents recursively in v0.2.4, recursive contents were not correctly parsed into objects. This release fixes that bug so that the recursive file tree is all `Pcloud::File` and `Pcloud::Folder` objects.
+
+## 0.2.4 2023-05-05
 
 **Changes**
   1. You can now specify `recursive: true` on `Pcloud::Folder#find` and `Pcloud::Folder#find_by` methods to load all the folders contents recursively. Note that this may result in long request times for folders with many items in them.

--- a/lib/pcloud/folder/parser.rb
+++ b/lib/pcloud/folder/parser.rb
@@ -23,7 +23,7 @@ module Pcloud
                   path: content_item["path"], # no path comes back from this api
                   name: content_item["name"],
                   parent_folder_id: content_item["parentfolderid"],
-                  contents: content_item["contents"], # no content comes back from this api
+                  contents: recursively_parse_contents(content_item["contents"]), # this can be `nil` if recursive is false
                   is_deleted: content_item["isdeleted"],
                   created_at: content_item["created"],
                   modified_at: content_item["modified"]
@@ -44,6 +44,39 @@ module Pcloud
               end
             end
           )
+        end
+
+        private
+
+        def recursively_parse_contents(contents)
+          return nil if contents.nil?
+          contents.map do |content_item|
+            if content_item["isfolder"]
+              Pcloud::Folder.new(
+                id: content_item["folderid"],
+                path: content_item["path"], # no path comes back from this api
+                name: content_item["name"],
+                parent_folder_id: content_item["parentfolderid"],
+                contents: recursively_parse_contents(content_item["contents"]),
+                is_deleted: content_item["isdeleted"],
+                created_at: content_item["created"],
+                modified_at: content_item["modified"]
+              )
+            else
+              Pcloud::File.new(
+                id: content_item["fileid"],
+                path: content_item["path"],
+                name: content_item["name"],
+                content_type: content_item["contenttype"],
+                category_id: content_item["category"],
+                size: content_item["size"],
+                parent_folder_id: content_item["parentfolderid"],
+                is_deleted: content_item["isdeleted"],
+                created_at: content_item["created"],
+                modified_at: content_item["modified"]
+              )
+            end
+          end
         end
       end
     end

--- a/lib/pcloud/version.rb
+++ b/lib/pcloud/version.rb
@@ -1,3 +1,3 @@
 module Pcloud
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/pcloud/folder_spec.rb
+++ b/spec/pcloud/folder_spec.rb
@@ -571,7 +571,7 @@ RSpec.describe Pcloud::Folder do
               "contenttype" => "image/jpg",
               "category" => 1,
               "size" => 1992312,
-              "parentfolderid" => 0,
+              "parentfolderid" => 9000,
               "created" => "Sat, 25 Sep 2021 04:44:32 +0000",
               "modified" => "Sat, 25 Sep 2021 05:44:32 +0000"
             },
@@ -582,6 +582,20 @@ RSpec.describe Pcloud::Folder do
               "parentfolderid" => 9000,
               "created" => "Sun, 26 Sep 2021 21:26:06 +0000",
               "modified" => "Sun, 26 Sep 2021 22:26:06 +0000",
+              "contents" => [
+                {
+                  "isfolder" => false,
+                  "fileid" => 100200,
+                  "name" => "only_jack.jpg",
+                  "path" => "/only_jack.jpg",
+                  "contenttype" => "image/jpg",
+                  "category" => 1,
+                  "size" => 1992332,
+                  "parentfolderid" => 10000,
+                  "created" => "Sun, 24 Apr 2022 19:11:36 +0000",
+                  "modified" => "Sun, 24 Apr 2022 19:11:36 +0000"
+                },
+              ]
             },
           ]
         }
@@ -633,6 +647,9 @@ RSpec.describe Pcloud::Folder do
       expect(contents.size).to eq(2)
       expect(contents.first).to be_a(Pcloud::File)
       expect(contents.last).to be_a(Pcloud::Folder)
+      # make sure recursive folder parsing is working
+      expect(contents.last.contents.size).to eq(1)
+      expect(contents.last.contents.first).to be_a(Pcloud::File)
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
### Description

After the new `recursive` argument added to folder finding in v0.2.4, recursive contents were being returned as hashes instead of being parsed out into `Pcloud::File` and `Pcloud::Folder` objects as intended. This PR updates folder contents parsing to work recursively when contents are present.